### PR TITLE
Add back admin settings menu bar.

### DIFF
--- a/src/apps/menu/admin-bar.vue
+++ b/src/apps/menu/admin-bar.vue
@@ -42,11 +42,6 @@
 
 <template>
   <div class="menu-admin">
-    <div class="hide-link-container">
-      <CLink @click="hooks.menu.hideAdminBar" mt="auto" variant="link">
-        Hide
-      </CLink>
-    </div>
     <div class="admin-link-container">
       <CLink
         :href="`${hooks.config.public.backendUrl}/admin`"
@@ -79,6 +74,11 @@
       />
       <FormKit type="submit" label="Save" size="sm" />
     </FormKit>
+    <div class="hide-link-container">
+      <CLink @click="hooks.menu.hideAdminBar" mt="auto" variant="link">
+        Hide
+      </CLink>
+    </div>
   </div>
 </template>
 
@@ -88,7 +88,8 @@
     color: var(--chakra-colors-blue-100);
     position: fixed;
     width: 100%;
-    bottom: 0;
+    top: 0;
+    left: 0;
     display: flex;
     align-items: center;
     gap: 2em;
@@ -97,10 +98,6 @@
     .hide-link-container {
       display: flex;
       align-items: center;
-      padding: 0 7.5em;
-    }
-
-    .admin-link-container {
       margin-left: auto;
     }
 

--- a/src/apps/portfolios/p-navbar.vue
+++ b/src/apps/portfolios/p-navbar.vue
@@ -1,3 +1,14 @@
+<script setup>
+import { urls } from "~/urls";
+import { useLeftMenu } from "~/apps/menu/useLeftMenu";
+import { useUserStore } from "~/apps/auth/useUserStore";
+
+const hooks = {
+  menu: useLeftMenu(),
+  userStore: useUserStore(),
+};
+</script>
+
 <template>
   <CFlex
     w="100%"
@@ -29,9 +40,20 @@
         </CBox>
       </CTooltip>
     </CFlex>
+    <CFlex ml="auto" align="center">
+      <CButton
+        v-if="hooks.userStore.user?.is_momentum_admin"
+        @click="hooks.menu.showAdminBar"
+        variant="link"
+      >
+        Admin settings
+      </CButton>
+    </CFlex>
+    <AdminBar v-if="hooks.userStore.user?.is_momentum_admin && hooks.menu.isAdminBarVisible.value" />
   </CFlex>
 </template>
 
-<script setup>
-import { urls } from "~/urls";
-</script>
+<style lang="scss">
+  @import '~/styles/chakra-ui.scss';
+  @import '~/styles/formkit.scss';
+</style>


### PR DESCRIPTION
This adds back the admin settings menu from the old stewardship site. The menu is now opened from the upper right corner and opens the admin bar in the top part of the window. I have tried to make tiny changes to reuse the existing code, and so have skipped moving any state handling etc., which is why it still uses "left menu" concepts even though that menu is gone.

Companion PR to only include active orgs in the menu options: https://github.com/givemomentum/stewardship-backend/pull/50

https://app.asana.com/0/1203169032707353/1204981598824092